### PR TITLE
fix: AJDA-2721 raise mongosh testConnection timeout for slow VPN connects

### DIFF
--- a/src/Extractor.php
+++ b/src/Extractor.php
@@ -54,19 +54,23 @@ class Extractor
     }
 
     /**
+     * connectTimeoutMS bounds the underlying TCP connect (slow VPN routes hung
+     * here previously). serverSelectionTimeoutMS bounds post-handshake driver
+     * selection. The Process wall-clock must comfortably exceed both so mongosh
+     * can emit a clean error instead of being SIGKILLed.
+     */
+    private const MONGOSH_CONNECT_TIMEOUT_MS = 10000;
+    private const MONGOSH_SERVER_SELECTION_TIMEOUT_MS = 5000;
+    private const MONGOSH_PROCESS_TIMEOUT_SECONDS = 60;
+
+    /**
      * Tests connection using mongosh CLI
      * @throws \Keboola\Component\UserException
      */
     public function testConnection(): void
     {
         $uri = $this->uriFactory->create($this->dbParams);
-
-        // Add short timeout to avoid long waits on unreachable hosts (only if not already set)
-        $uriString = (string) $uri;
-        if (!$uri->getQuery()->has('serverSelectionTimeoutMS')) {
-            $separator = str_contains($uriString, '?') ? '&' : '?';
-            $uriString .= $separator . 'serverSelectionTimeoutMS=5000';
-        }
+        $uriString = self::appendMongoshTimeouts($uri);
 
         $command = ['mongosh', $uriString, '--eval', 'db.runCommand({listCollections: 1})', '--quiet', '--norc'];
 
@@ -82,7 +86,7 @@ class Extractor
 
         $this->retryProxy->call(function () use ($command): void {
             $process = new Process($command);
-            $process->setTimeout(30);
+            $process->setTimeout(self::MONGOSH_PROCESS_TIMEOUT_SECONDS);
             $process->run();
 
             if (!$process->isSuccessful()) {
@@ -94,6 +98,32 @@ class Extractor
                 throw new UserException($errorMessage);
             }
         });
+    }
+
+    /**
+     * Appends connectTimeoutMS and serverSelectionTimeoutMS to a mongosh URI so
+     * a connect failure surfaces as a clean MongoNetworkError instead of being
+     * killed by the wrapping Process timeout. User-supplied values take
+     * precedence — caller-provided timeouts are never overridden.
+     */
+    public static function appendMongoshTimeouts(Uri $uri): string
+    {
+        $defaults = [
+            'connectTimeoutMS' => self::MONGOSH_CONNECT_TIMEOUT_MS,
+            'serverSelectionTimeoutMS' => self::MONGOSH_SERVER_SELECTION_TIMEOUT_MS,
+        ];
+
+        $uriString = (string) $uri;
+        $query = $uri->getQuery();
+
+        foreach ($defaults as $key => $value) {
+            if (!$query->has($key)) {
+                $separator = str_contains($uriString, '?') ? '&' : '?';
+                $uriString .= $separator . $key . '=' . $value;
+            }
+        }
+
+        return $uriString;
     }
 
     /**

--- a/tests/phpunit/ExtractorAppendMongoshTimeoutsTest.php
+++ b/tests/phpunit/ExtractorAppendMongoshTimeoutsTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MongoExtractor\Tests\Unit;
+
+use MongoExtractor\Extractor;
+use MongoExtractor\UriFactory;
+use PHPUnit\Framework\TestCase;
+
+class ExtractorAppendMongoshTimeoutsTest extends TestCase
+{
+    private UriFactory $uriFactory;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->uriFactory = new UriFactory();
+    }
+
+    public function testAddsBothTimeoutsToCleanUri(): void
+    {
+        $uri = $this->uriFactory->create([
+            'host' => 'localhost',
+            'port' => 27017,
+            'database' => 'myDatabase',
+        ]);
+
+        $result = Extractor::appendMongoshTimeouts($uri);
+
+        self::assertStringContainsString('connectTimeoutMS=10000', $result);
+        self::assertStringContainsString('serverSelectionTimeoutMS=5000', $result);
+        // Original URI is preserved
+        self::assertStringStartsWith('mongodb://localhost:27017/myDatabase?', $result);
+    }
+
+    public function testAddsTimeoutsAfterExistingQueryParams(): void
+    {
+        $uri = $this->uriFactory->create([
+            'host' => 'localhost',
+            'port' => 27017,
+            'database' => 'myDatabase',
+            'user' => 'user',
+            'password' => 'pass',
+            'authenticationDatabase' => 'authDb',
+        ]);
+
+        $result = Extractor::appendMongoshTimeouts($uri);
+
+        // Existing authSource preserved, both timeouts appended
+        self::assertStringContainsString('authSource=authDb', $result);
+        self::assertStringContainsString('connectTimeoutMS=10000', $result);
+        self::assertStringContainsString('serverSelectionTimeoutMS=5000', $result);
+    }
+
+    public function testDoesNotOverrideUserSuppliedServerSelectionTimeout(): void
+    {
+        // custom_uri with a user-supplied serverSelectionTimeoutMS
+        $uri = $this->uriFactory->create([
+            'protocol' => 'custom_uri',
+            'uri' => 'mongodb://user@localhost:27017/db?serverSelectionTimeoutMS=20000',
+            'password' => 'pass',
+        ]);
+
+        $result = Extractor::appendMongoshTimeouts($uri);
+
+        // Existing value preserved (not duplicated)
+        self::assertStringContainsString('serverSelectionTimeoutMS=20000', $result);
+        self::assertStringNotContainsString('serverSelectionTimeoutMS=5000', $result);
+        // connectTimeoutMS still added since user did not provide it
+        self::assertStringContainsString('connectTimeoutMS=10000', $result);
+    }
+
+    public function testDoesNotOverrideUserSuppliedConnectTimeout(): void
+    {
+        $uri = $this->uriFactory->create([
+            'protocol' => 'custom_uri',
+            'uri' => 'mongodb://user@localhost:27017/db?connectTimeoutMS=30000',
+            'password' => 'pass',
+        ]);
+
+        $result = Extractor::appendMongoshTimeouts($uri);
+
+        self::assertStringContainsString('connectTimeoutMS=30000', $result);
+        self::assertStringNotContainsString('connectTimeoutMS=10000', $result);
+        self::assertStringContainsString('serverSelectionTimeoutMS=5000', $result);
+    }
+
+    public function testDoesNotDuplicateWhenBothAlreadyPresent(): void
+    {
+        $uri = $this->uriFactory->create([
+            'protocol' => 'custom_uri',
+            'uri' => 'mongodb://user@localhost:27017/db?connectTimeoutMS=15000&serverSelectionTimeoutMS=15000',
+            'password' => 'pass',
+        ]);
+
+        $result = Extractor::appendMongoshTimeouts($uri);
+
+        self::assertSame(1, substr_count($result, 'connectTimeoutMS='));
+        self::assertSame(1, substr_count($result, 'serverSelectionTimeoutMS='));
+        self::assertStringContainsString('connectTimeoutMS=15000', $result);
+        self::assertStringContainsString('serverSelectionTimeoutMS=15000', $result);
+    }
+}


### PR DESCRIPTION
## Summary

Regression introduced in v3.3.2 (commit ed89eb24, AJDA-2621 / PR #35) where the mongosh-based `testConnection()` got a hardcoded 30 s Process timeout that collides exactly with the Node MongoDB driver's default `connectTimeoutMS=30000`. On slow VPN-routed connections (Heureka, ticket [SUPPORT-16285](https://keboola.atlassian.net/browse/SUPPORT-16285)), the PHP Process kills mongosh before the driver can emit a clean error, and `testConnection()` runs at the start of every `extract()` — so every nightly job fails after 5 retries.

`serverSelectionTimeoutMS=5000` (already in the URI) does not help: it only counts post-handshake server-selection time. The blocking phase is TCP connect / DNS, governed by `connectTimeoutMS`.

### Changes

- `src/Extractor.php::testConnection()` now injects `connectTimeoutMS=10000` alongside the existing `serverSelectionTimeoutMS=5000`. User-supplied values in `custom_uri` configs are preserved — defaults only apply when the user didn't set them.
- Process wall-clock timeout raised from 30 s → 60 s, comfortably above the sum of driver-level timeouts so mongosh produces a useful error instead of being SIGKILLed.
- URI augmentation extracted into `Extractor::appendMongoshTimeouts(Uri): string` static helper for unit testing.

## Test plan

- [x] 5 new unit tests in `ExtractorAppendMongoshTimeoutsTest`: both defaults added to clean URI / preserved alongside existing query params / never override user-supplied `connectTimeoutMS` / never override user-supplied `serverSelectionTimeoutMS` / no duplication when both already present.
- [x] `composer ci` — composer validate, phplint, phpcs, phpstan level 8, 111 unit tests, 79 functional tests. All green.
- [ ] Customer verification (Heureka, project 672) once released — confirm nightly extraction jobs stop timing out.
- [ ] Datadog query [linked in ticket](https://app.datadoghq.eu/logs?query=componentid%3Akeboola.ex-mongodb%20%22exceeded%20the%20timeout%20of%2030%20seconds%22) — should drop to zero matches after release.

## Release Notes

- **Justification**
    - The MongoDB extractor's nightly scheduled jobs fail with timeout errors for customers on VPN-routed connections (Heureka). The 30 s mongosh process timeout introduced in v3.3.2 races with the Node MongoDB driver's own 30 s TCP connect timeout, killing the process before it can emit a useful error. Customer-facing impact is failed nightly extractions and no actionable error message.
    - We explicitly cap TCP connect at 10 s, server-selection at 5 s, and the wall-clock at 60 s, so the driver always emits a clean error and slow-but-functional VPN routes can complete the connection test.

- **Plans for Customer Communication**
    - No proactive comms required — affected customers (Heureka and any other VPN-routed setup) will silently see their jobs start succeeding again. Support team to notify Heureka contact (Olena → Hana Bedrichova) when released.

- **Impact Analysis**
    - Positive impact: previously failing extractions on slow VPN routes will succeed.
    - Negative impact: testConnection on a truly unreachable host now fails in ~10 s (clean error) instead of ~30 s (Process kill). No customer-visible regression.
    - Not behind a feature flag — applies to all customers. No tenant-specific behavior.

- **Deployment Plan**
    - Continuous deployment. Not labelled critical — change is narrow, well-tested, and has an obvious revert path.

- **Rollback Plan**
    - Single commit revert; no migrations or state changes. Two-way door.

- **Post-Release Support Plan**
    - Notify Olena (Support, SUPPORT-16285) when released so Heureka can verify the next nightly run.
    - Monitor Datadog query for `\"exceeded the timeout of 30 seconds\"` to confirm zero hits post-release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SUPPORT-16285]: https://keboola.atlassian.net/browse/SUPPORT-16285?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ