### PR TITLE
Surface MongoDB authentication failures as a UserException

### DIFF
--- a/src/Export.php
+++ b/src/Export.php
@@ -133,6 +133,13 @@ class Export
                 'connection handshake: dial tcp: i/o timeout');
         }
 
+        if (str_contains($e->getMessage(), '(AuthenticationFailed)')
+            || str_contains($e->getMessage(), 'unable to authenticate')
+        ) {
+            throw new UserException('Could not authenticate against the MongoDB server. ' .
+                'Please check the configured username, password and authentication database.');
+        }
+
         if (str_contains($e->getMessage(), 'error parsing URI')
             || str_contains($e->getMessage(), 'error parsing uri')
         ) {

--- a/tests/phpunit/HandleMongoExportFailsTest.php
+++ b/tests/phpunit/HandleMongoExportFailsTest.php
@@ -80,6 +80,15 @@ class HandleMongoExportFailsTest extends TestCase
                 'execute command'),
         ];
 
+        yield 'AuthenticationFailed' => [
+            new ProcessFailedException($this->createMockInstanceOfProcess('2026-07-23T09:02:25.402+0000\t' .
+                'failed to connect to mongodb://[**REDACTED**]/production: connection() error occurred during ' .
+                'connection handshake: auth error: sasl conversation error: unable to authenticate using ' .
+                'mechanism "SCRAM-SHA-1": (AuthenticationFailed) Authentication failed.')),
+            new UserException('Could not authenticate against the MongoDB server. ' .
+                'Please check the configured username, password and authentication database.'),
+        ];
+
         yield 'field names may not start with $' => [
             new ProcessFailedException($this->createMockInstanceOfProcess('2023-05-17T12:49:22.079+0000\t' .
                 'connected to: mongodb+srv://[**REDACTED**]@cl-shared-all-prod-web.x0u5m.mongodb.net/slotManagementDB' .


### PR DESCRIPTION
## What

`mongoexport` can fail to authenticate against the MongoDB server (e.g. wrong username/password/auth DB). Today that error is not matched by any branch in `Export::handleMongoExportFails()`, so it falls through to the re-thrown `ProcessFailedException` and the job ends with an **opaque application/internal error (exit code 2)** — which pages the team and shows the customer nothing actionable.

This adds one more signature branch to the **existing** error-classification method (same `str_contains(...) -> throw new UserException(...)` idiom already used for `dial tcp: i/o timeout`, URI parse errors, etc.) so an authentication failure is surfaced as a clear **`UserException` (exit code 1)**:

> Could not authenticate against the MongoDB server. Please check the configured username, password and authentication database.

## Root cause

- Exception: `Symfony\Component\Process\Exception\ProcessFailedException` — the `mongoexport` child process exits non-zero.
- Deepest component frame: `src/Export.php:69` (`Export::export()`), which delegates to `handleMongoExportFails()`.
- Underlying `mongoexport` stderr: `auth error: sasl conversation error: unable to authenticate using mechanism "SCRAM-SHA-1": (AuthenticationFailed) Authentication failed.`
- Deterministic and user-actionable (invalid credentials); it will not resolve on retry, so it belongs as a `UserException`, not a retry.

## Behaviour impact: none — defensive-only

- The added branch lives inside `handleMongoExportFails()`, which is only invoked when `!$process->isSuccessful()`. The successful-export path never enters it.
- It only catches messages that **previously fell through unhandled** to a raw exit-2 crash; every existing signature still matches first and behaves identically.
- It re-raises (as `UserException`) — the job still fails, only more legibly (exit 2 -> exit 1). Nothing is swallowed; no output, schema, ordering, or row set changes.
- No existing test assertion was modified or removed.

## Tests

- Added a regression case (`AuthenticationFailed`) to the existing `HandleMongoExportFailsTest` data provider, asserting the auth-failure stderr is re-raised as the new `UserException` with its message.
- Existing hermetic unit suite (`tests/phpunit`) is otherwise unchanged; CI validates the full suite (phplint / phpcs / phpstan / phpunit).
