### PR TITLE
fix: surface MongoDB quiesce-mode shutdown as user error

### DIFF
--- a/src/Export.php
+++ b/src/Export.php
@@ -147,6 +147,16 @@ class Export
             throw new UserException('FieldPath field names may not start with \'$\'');
         }
 
+        if (str_contains($e->getMessage(), 'ShutdownInProgress')
+            || str_contains($e->getMessage(), 'Mongos is in quiesce mode')
+        ) {
+            throw new UserException(
+                'The MongoDB server is shutting down or restarting (Mongos is in quiesce mode), ' .
+                'so the export could not be completed. This is usually a temporary state caused by ' .
+                'server maintenance or a failover. Please try running the extraction again in a few minutes.',
+            );
+        }
+
         if (preg_match('/(Failed:.*?command)/s', $e->getMessage(), $matches)) {
             throw new UserException(trim($matches[1]));
         }

--- a/tests/phpunit/HandleMongoExportFailsTest.php
+++ b/tests/phpunit/HandleMongoExportFailsTest.php
@@ -82,8 +82,8 @@ class HandleMongoExportFailsTest extends TestCase
 
         yield 'ShutdownInProgress / quiesce mode' => [
             new ProcessFailedException($this->createMockInstanceOfProcess('2026-07-20T08:41:54.107+0000\t' .
-                'apifier-prod.act2Runs\t466797 2026-07-20T08:41:54.107+0000\tFailed:  connection pool for ' .
-                'apify-prod-shard-02-01-shcdj.mongodb.net:27016 was cleared because another operation failed with: ' .
+                'example-db.exampleCollection\t466797 2026-07-20T08:41:54.107+0000\tFailed:  connection pool for ' .
+                'shard-00-01.example.mongodb.net:27016 was cleared because another operation failed with: ' .
                 '(ShutdownInProgress) Mongos is in quiesce mode and will shut down')),
             new UserException(
                 'The MongoDB server is shutting down or restarting (Mongos is in quiesce mode), ' .

--- a/tests/phpunit/HandleMongoExportFailsTest.php
+++ b/tests/phpunit/HandleMongoExportFailsTest.php
@@ -80,6 +80,18 @@ class HandleMongoExportFailsTest extends TestCase
                 'execute command'),
         ];
 
+        yield 'ShutdownInProgress / quiesce mode' => [
+            new ProcessFailedException($this->createMockInstanceOfProcess('2026-07-20T08:41:54.107+0000\t' .
+                'apifier-prod.act2Runs\t466797 2026-07-20T08:41:54.107+0000\tFailed:  connection pool for ' .
+                'apify-prod-shard-02-01-shcdj.mongodb.net:27016 was cleared because another operation failed with: ' .
+                '(ShutdownInProgress) Mongos is in quiesce mode and will shut down')),
+            new UserException(
+                'The MongoDB server is shutting down or restarting (Mongos is in quiesce mode), ' .
+                'so the export could not be completed. This is usually a temporary state caused by ' .
+                'server maintenance or a failover. Please try running the extraction again in a few minutes.',
+            ),
+        ];
+
         yield 'field names may not start with $' => [
             new ProcessFailedException($this->createMockInstanceOfProcess('2023-05-17T12:49:22.079+0000\t' .
                 'connected to: mongodb+srv://[**REDACTED**]@cl-shared-all-prod-web.x0u5m.mongodb.net/slotManagementDB' .


### PR DESCRIPTION
## Summary
When `mongoexport` fails because the MongoDB server (mongos) is restarting/shutting down, it emits an error like:

```
Failed: connection pool for ...:27016 was cleared because another operation failed with:
(ShutdownInProgress) Mongos is in quiesce mode and will shut down
```

This message did not match any of the existing patterns in `Export::handleMongoExportFails()`, so it fell through to `throw $e;` and surfaced in the UI as a **generic internal server error** (ExceptionId), hiding the real cause from the user.

This adds a handler that detects `ShutdownInProgress` / `Mongos is in quiesce mode` and rethrows as a `UserException`, so the job log shows an actionable message instead:

```php
if (str_contains($e->getMessage(), 'ShutdownInProgress')
    || str_contains($e->getMessage(), 'Mongos is in quiesce mode')
) {
    throw new UserException(
        'The MongoDB server is shutting down or restarting (Mongos is in quiesce mode), '
        . 'so the export could not be completed. This is usually a temporary state caused by '
        . 'server maintenance or a failover. Please try running the extraction again in a few minutes.',
    );
}
```

The check is placed before the generic `/(Failed:.*?command)/s` fallback and joins the existing family of translated `mongoexport` errors (`Failed: EOF`, `dial tcp: i/o timeout`, etc.). Since it becomes a `UserException`, the retry policy in `getRetryPolicy()` already treats it as non-retryable.

A unit test case (`ShutdownInProgress / quiesce mode`) using the exact error output from the reported job (SUPPORT job 1319494932) is added to `HandleMongoExportFailsTest`.

## Release Notes
**Justification, description**

Transient MongoDB "quiesce mode" shutdown errors during `mongoexport` were shown to users as a generic internal server error. They are now translated into a clear, actionable user error in the job log.

**Plans for Customer Communication**

N/A

**Impact Analysis**

N/A

**Deployment Plan**

N/A

**Rollback Plan**

N/A

**Post-Release Support Plan**

N/A


Link to Devin session: https://app.devin.ai/sessions/beef5b5d8a684749a5cc5e58b33b87f0
Requested by: @terezaskalova