### PR TITLE
Defensive fix: surface a MongoDB connection-handshake timeout as a UserException in keboola.ex-mongodb

### DIFF
--- a/src/Export.php
+++ b/src/Export.php
@@ -175,6 +175,27 @@ class Export
             ));
         }
 
+        // Deliberately last, so it only catches messages that would otherwise fall through to the
+        // rethrow below: every branch above keeps its existing message and priority (the auth
+        // failure above also mentions the connection handshake, and must stay on its own branch).
+        // mongoexport reports a connection-establishment timeout in shapes the 'dial tcp: i/o
+        // timeout' check above does not match — the host:port sits in the middle of the string, or
+        // the driver reports a server-selection timeout instead — so those surfaced as an opaque
+        // internal error. Both a handshake/selection marker and a timeout marker are required, so
+        // a non-timeout handshake failure cannot match this branch.
+        if ((str_contains($e->getMessage(), 'error occurred during connection handshake')
+                || str_contains($e->getMessage(), 'server selection error'))
+            && (str_contains($e->getMessage(), 'i/o timeout')
+                || str_contains($e->getMessage(), 'context deadline exceeded'))
+        ) {
+            throw new UserException(
+                'Could not connect to the MongoDB server: the connection timed out while establishing ' .
+                'the session. This is usually a temporary network problem, or the server is unreachable ' .
+                'or overloaded. Please check the configured host, port and network access, then try ' .
+                'running the extraction again.',
+            );
+        }
+
         throw $e;
     }
 

--- a/tests/phpunit/HandleMongoExportFailsTest.php
+++ b/tests/phpunit/HandleMongoExportFailsTest.php
@@ -101,6 +101,29 @@ class HandleMongoExportFailsTest extends TestCase
                 'Please check the configured username, password and authentication database.'),
         ];
 
+        // The 'dial tcp: i/o timeout' case above uses a shortened message. In production the Go
+        // driver puts the host:port between "dial tcp" and "i/o timeout", so that check never
+        // matched a real handshake timeout and it fell through as an opaque internal error.
+        yield 'connection handshake i/o timeout (real message, host:port in the middle)' => [
+            new ProcessFailedException($this->createMockInstanceOfProcess('2026-07-30T03:14:11.204+0000\t' .
+                'Failed: error connecting to db server: connection() error occurred during connection ' .
+                'handshake: dial tcp 10.20.30.40:27017: i/o timeout')),
+            new UserException('Could not connect to the MongoDB server: the connection timed out while ' .
+                'establishing the session. This is usually a temporary network problem, or the server is ' .
+                'unreachable or overloaded. Please check the configured host, port and network access, ' .
+                'then try running the extraction again.'),
+        ];
+
+        yield 'server selection timeout (context deadline exceeded)' => [
+            new ProcessFailedException($this->createMockInstanceOfProcess('2026-07-30T03:14:11.204+0000\t' .
+                'Failed: error connecting to db server: server selection error: context deadline exceeded, ' .
+                'current topology: { Type: ReplicaSetNoPrimary, Servers: [ ... ] }')),
+            new UserException('Could not connect to the MongoDB server: the connection timed out while ' .
+                'establishing the session. This is usually a temporary network problem, or the server is ' .
+                'unreachable or overloaded. Please check the configured host, port and network access, ' .
+                'then try running the extraction again.'),
+        ];
+
         yield 'field names may not start with $' => [
             new ProcessFailedException($this->createMockInstanceOfProcess('2023-05-17T12:49:22.079+0000\t' .
                 'connected to: mongodb+srv://[**REDACTED**]@cl-shared-all-prod-web.x0u5m.mongodb.net/slotManagementDB' .


### PR DESCRIPTION
## Summary
Adds defensive handling for an unhandled `mongoexport` connection-handshake timeout observed
in production. No change to the component's behaviour on inputs that already worked.

## Root cause
`Symfony\Component\Process\Exception\ProcessFailedException` from `Export::export()`
(`src/Export.php:69` → `handleMongoExportFails`) — mongoexport could not establish the
MongoDB session and reported a handshake / server-selection timeout. Classified as
**transient, surfaced as user-actionable (exit 2 → 1)**; 2 occurrences in the alert window.

`handleMongoExportFails` already *intends* to cover this: there is a
`str_contains($e->getMessage(), 'dial tcp: i/o timeout')` branch. But the Go driver puts the
address between the two halves, so the real message is

```
Failed: error connecting to db server: connection() error occurred during
connection handshake: dial tcp 10.20.30.40:27017: i/o timeout
```

which does **not** contain the contiguous substring `dial tcp: i/o timeout`. (The existing unit
test for that branch uses a shortened message, which is why the gap went unnoticed.) A
server-selection timeout — `server selection error: context deadline exceeded` — misses it too.
Both therefore fell through to the final `throw $e` and exited **2** (opaque internal error,
pages the team) rather than **1** (a clear user error).

## Fix
Add one branch to `handleMongoExportFails` that requires **both** a connection-establishment
marker (`error occurred during connection handshake` or `server selection error`) **and** a
timeout marker (`i/o timeout` or `context deadline exceeded`), and raise a `UserException`
explaining the connection timed out and suggesting a retry.

Two placement decisions make this order-independent and non-invasive:
- It is appended **last**, immediately before the existing `throw $e`, so it can only catch
  messages that previously fell through as opaque internal errors. Every branch above keeps
  its exact message and priority.
- It requires the timeout marker **in addition** to the handshake marker, so it cannot
  preempt the existing `AuthenticationFailed` branch — whose message also mentions
  "error occurred during connection handshake" but carries no timeout marker.

## Behaviour impact: none — defensive-only
- Happy path unchanged; no outputs, transforms, schema, or config semantics touched.
- The job still fails — the error is re-raised as a `UserException` (same failure, now a clear
  exit-1 user error instead of an opaque exit-2 internal error). Nothing is swallowed.
- **No retry is removed.** `getRetryPolicy()` does not retry `UserException`, so this was
  checked explicitly: `handleMongoExportFails` is never called inside a `RetryProxy` —
  `Export` retries only `$process->start()` (`src/Export.php:56`) and `Extractor` retries only
  `testConnection()` (`src/Extractor.php:87`). The failing call site is outside both.
- Every pre-existing branch keeps its message; no existing behaviour is re-routed.
- **The diff is 44 insertions and 0 deletions** — nothing existing was edited or removed.

## Evidence
Datadog: https://app.datadoghq.eu/monitors/97152903

## Tests
Run in a container (this repo is Docker-only; there is no local PHP):
- `vendor/bin/phpunit tests/phpunit` — **129 passed** (127 pre-existing, unchanged; 2 added).
- `vendor/bin/phpstan analyse --level=8 src tests` — no errors.
- `vendor/bin/phpcs --standard=phpcs.xml src tests` — 0 errors (the single warning is
  pre-existing, in the untouched `tests/functional/export-no-space-left-on-device/setUp.php`).

Added two `HandleMongoExportFailsTest` provider cases: the real handshake `i/o timeout`
message with `host:port` in the middle, and a `server selection error: context deadline
exceeded`. The existing `AuthenticationFailed` case — which also contains the handshake
phrase — still asserts its own auth message, guarding the branch ordering.